### PR TITLE
Update the git URL in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ When rmux hit production, we saw immediate gains in our 90th-percentile and uppe
 ## Installing ##
 
 - Install [Go](http://golang.org/doc/install) 
-- go get -u github.com/Pardot/rmux
-- go build -o /usr/local/bin/rmux github.com/Pardot/rmux/main
+- go get -u github.com/SalesforceEng/rmux
+- go build -o /usr/local/bin/rmux github.com/SalesforceEng/rmux/main
 
 
 ## Usage ##


### PR DESCRIPTION
`README.md` contains an old `git` repository path for `rmux`. This updates it to the current path.